### PR TITLE
Added human readable names

### DIFF
--- a/pagi.md
+++ b/pagi.md
@@ -321,20 +321,20 @@ Here is the general structure:
 
 ```xml
 <pagis xmlns="http://pagi.org/schema/" 
-       pagis-uri="http://www.example.com/spec-example-1">
-  <nodeType name="" idGenerator="">
+       pagis-uri="http://www.example.com/spec-example-1" readableName="">
+  <nodeType name="" readableName="" idGenerator="">
     <span/>
     <sequence/>
     <container edgeType=""/>
     <spanContainer spanType=""/>
-    <integerProperty name="" minRange="" maxRange="" minArity="" maxArity=""/>
-    <floatProperty name="" minRange="" maxRange="" minArity="" maxArity=""/>
-    <booleanProperty name="" minArity="" maxArity=""/>
-    <stringProperty name="" minArity="" maxArity=""/>
-    <enumProperty name="" minArity="" maxArity="">
-      <item name=""/>
+    <integerProperty name="" readableName=""  minRange="" maxRange="" minArity="" maxArity=""/>
+    <floatProperty name="" readableName="" minRange="" maxRange="" minArity="" maxArity=""/>
+    <booleanProperty name="" readableName="" minArity="" maxArity=""/>
+    <stringProperty name="" readableName="" minArity="" maxArity=""/>
+    <enumProperty name="" readableName="" minArity="" maxArity="">
+      <item name="" readableName=""/>
     </enum>
-    <edgeType name="" targetNodeType="" minArity="" maxArity="" targetMinArity="" targetMaxArity=""/>
+    <edgeType name="" readableName="" targetNodeType="" minArity="" maxArity="" targetMinArity="" targetMaxArity=""/>
     <edgeType name="" minArity="" maxArity="" targetMinArity="" targetMaxArity="">
       <targetNodeType name=""/>
       <targetNodeType name=""/>
@@ -352,6 +352,13 @@ node with the Contains-Sequence trait) would be designated by the attributes
 min="1", max="unbounded". The "targetMinArity" and "targetMaxArity" attributes
 on the edge element specify the same limitations, except on the node type that
 the edge is targeting.
+
+The "readableName" attributes on pagis, nodeType, edge, property, and item XML
+elements each defines an alias for its element, allowing the "name" to be more
+of an abbreviation and the "readableName" to be more clear. The "readableName"
+is optional and unimportant in the implementation of the data structure. In all
+references to nodeTypes, the "name" attribute will define the String value to
+be used, NOT the "readableName" attribute.
 
 #### Id Generator
 
@@ -436,12 +443,14 @@ style conventions in the appropriate language.
 #### Schema
 
 * String getName()
+* String getReadableName()
 * Map(String, NodeType) getNodeTypes()
 * Schema getParentSchema()
 
 #### NodeType
 
 * String getName()
+* String getReadableName()
 * boolean isSpan()
 * boolean isSequence()
 * boolean isContainer()
@@ -455,6 +464,7 @@ style conventions in the appropriate language.
 
 * ValueType getValueType()
 * String getName()
+* String getReadableName()
 * int getMinArity()
 * int getMaxArity() // -1 represents unbounded unless a language has a better 
   representation
@@ -476,9 +486,15 @@ style conventions in the appropriate language.
 
 * String[] getItems()
 
+###### Items
+
+* String getName()
+* String getReadableName()
+
 #### EdgeSpec
 
 * String getName()
+* String getReadableName()
 * String[] getTargetNodeTypes()
 * int getMinArity()
 * int getMaxArity()

--- a/resources/pagis.xsd
+++ b/resources/pagis.xsd
@@ -145,6 +145,7 @@
 			<xsd:element name="item" minOccurs="1" maxOccurs="unbounded">
 				<xsd:complexType>
 					<xsd:attribute name="name" type="xsd:string"/>
+					<xsd:attribute name="readableName" type="xsd:string" use="optional"/>
 				</xsd:complexType>
 			</xsd:element>
 		</xsd:sequence>

--- a/resources/pagis.xsd
+++ b/resources/pagis.xsd
@@ -21,6 +21,7 @@
 			</xsd:choice>
 		</xsd:sequence>
 		<xsd:attribute name="id" type="xsd:anyURI" use="required"/>
+		<xsd:attribute name="readableName" type="xsd:string" use="optional"/>
 	</xsd:complexType>
 
 	<xsd:complexType name="pagis-fragment">

--- a/resources/pagis.xsd
+++ b/resources/pagis.xsd
@@ -59,6 +59,7 @@
 		</xsd:sequence>
 		<xsd:attribute name="name" type="identifier" use="required"/>
 		<xsd:attribute name="idGenerator" type="idGenerator" use="required"/>
+		<xsd:attribute name="readableName" type="xsd:string" use="optional" /> <!-- The human readable name -->
 	</xsd:complexType>
 
 	<xsd:complexType name="fragmentNodeType">
@@ -74,6 +75,7 @@
 			<xsd:element name="edgeType" type="complexEdgeType" minOccurs="0" maxOccurs="unbounded"/>
 		</xsd:sequence>
 		<xsd:attribute name="name" type="identifier" use="required"/>
+		<xsd:attribute name="readableName" type="xsd:string" use="optional" /> <!-- The human readable name -->
 	</xsd:complexType>
 
 	<xsd:simpleType name="idGenerator">
@@ -150,6 +152,7 @@
 
 	<xsd:attributeGroup name="propertyBase">
 		<xsd:attribute name="name" type="identifier"/>
+		<xsd:attribute name="readableName" type="xsd:string" use="optional" /> <!-- The human readable name -->
 		<xsd:attribute name="minArity" type="xsd:nonNegativeInteger"/>
 		<xsd:attribute name="maxArity" type="maxArity"/>
 	</xsd:attributeGroup>
@@ -176,6 +179,7 @@
 			</xsd:element>
 		</xsd:sequence>
 		<xsd:attribute name="name" type="identifier"/>
+		<xsd:attribute name="readableName" type="xsd:string" use="optional" /> <!-- The human readable name -->
 		<xsd:attribute name="targetNodeType" type="identifier"/>
 		<xsd:attribute name="minArity" type="xsd:nonNegativeInteger"/>
 		<xsd:attribute name="maxArity" type="maxArity"/>
@@ -200,6 +204,7 @@
 			</xsd:choice>
 		</xsd:sequence>
 		<xsd:attribute name="name" type="identifier"/>
+		<xsd:attribute name="readableName" type="xsd:string" use="optional" /> <!-- The human readable name -->
 		<xsd:attribute name="targetNodeType" type="identifier"/>
 		<xsd:attribute name="minArity" type="xsd:nonNegativeInteger"/>
 		<xsd:attribute name="maxArity" type="maxArity"/>


### PR DESCRIPTION
Human readable names are possible in NodeTypes, fragmentNodeTypes, edgeSpecs, propertySpecs, and their extensions with the field "readableName"
